### PR TITLE
Fixed the `KernelFactory` which was retrieving `deployment` property instead of `organization` when building a kernel's OpenAI reasoning capabilities

### DIFF
--- a/src/DClare.Runtime.Api/DClare.Runtime.Api.csproj
+++ b/src/DClare.Runtime.Api/DClare.Runtime.Api.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	<VersionPrefix>0.1.0</VersionPrefix>
+	<VersionPrefix>0.1.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/DClare.Runtime.Application/DClare.Runtime.Application.csproj
+++ b/src/DClare.Runtime.Application/DClare.Runtime.Application.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<VersionPrefix>0.1.0</VersionPrefix>
+	<VersionPrefix>0.1.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/DClare.Runtime.Application/Services/KernelFactory.cs
+++ b/src/DClare.Runtime.Application/Services/KernelFactory.cs
@@ -122,9 +122,9 @@ public class KernelFactory(ILoggerFactory loggerFactory, IOAuth2TokenManager oau
                 kernelBuilder.AddOnnxRuntimeGenAIChatCompletion(reasoningCapability.Model, path, reasoningCapability.Provider);
                 break;
             case ReasoningModelProvider.OpenAI:
-                var organization = reasoningCapability.Api.Properties == null || !reasoningCapability.Api.Properties.TryGetValue("deployment", out value) ? null : value as string;
+                var organization = reasoningCapability.Api.Properties == null || !reasoningCapability.Api.Properties.TryGetValue("organization", out value) ? null : value as string;
                 if (string.IsNullOrWhiteSpace(apiKey)) throw new NullReferenceException("Failed to resolve the API Key to use");
-                if (reasoningCapability.Api.Endpoint == null) kernelBuilder.AddOpenAIChatCompletion(reasoningCapability.Model, apiKey, organization, reasoningCapability.Provider);
+                if (reasoningCapability.Api.Endpoint.Uri == null) kernelBuilder.AddOpenAIChatCompletion(reasoningCapability.Model, apiKey, organization, reasoningCapability.Provider);
                 else kernelBuilder.AddOpenAIChatCompletion(reasoningCapability.Model, reasoningCapability.Api.Endpoint.Uri, apiKey, organization, reasoningCapability.Provider);
                 break;
             default:

--- a/src/DClare.Runtime.Integration/DClare.Runtime.Integration.csproj
+++ b/src/DClare.Runtime.Integration/DClare.Runtime.Integration.csproj
@@ -4,7 +4,7 @@
 	<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Fixes the `KernelFactory` which was retrieving `deployment` property instead of `organization` when building a kernel's OpenAI reasoning capabilities