### PR TITLE
Make `ApplicationOptions` inherit from `Manifest` and support cache configuration

### DIFF
--- a/src/DClare.Runtime.Api/Controllers/ProcessesController.cs
+++ b/src/DClare.Runtime.Api/Controllers/ProcessesController.cs
@@ -32,7 +32,7 @@ public class ProcessesController(IMediator mediator)
     /// <returns>A new <see cref="IActionResult"/> that describes the result of the operation</returns>
     [HttpPost("invoke")]
     [ProducesResponseType(typeof(ChatResponse), (int)HttpStatusCode.OK)]
-    public virtual async Task<IActionResult> InvokeAgentAsync([FromBody] InvokeProcessCommand command, CancellationToken cancellationToken)
+    public virtual async Task<IActionResult> InvokeProcessAsync([FromBody] InvokeProcessCommand command, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid) return ValidationProblem(ModelState);
         var result = await mediator.ExecuteAsync(command, cancellationToken).ConfigureAwait(false);

--- a/src/DClare.Runtime.Api/DClare.Runtime.Api.csproj
+++ b/src/DClare.Runtime.Api/DClare.Runtime.Api.csproj
@@ -18,11 +18,10 @@
   <ItemGroup>
     <PackageReference Include="a2a-net.Server.AspNetCore" Version="0.4.1" />
 	<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-	<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
 	<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
 	<PackageReference Include="Neuroglia.Mediation.AspNetCore" Version="4.21.0" />
-	<PackageReference Include="Scalar.AspNetCore" Version="2.1.16" />
+	<PackageReference Include="Scalar.AspNetCore" Version="2.2.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="runtime.yaml">
+    <None Update="manifest.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/DClare.Runtime.Api/Program.cs
+++ b/src/DClare.Runtime.Api/Program.cs
@@ -11,20 +11,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using DClare.Runtime.Application;
-
 var builder = WebApplication.CreateBuilder(args);
-builder.Configuration.AddYamlFile("runtime.yaml", true);
-builder.Services.AddOptions<ApplicationOptions>().Bind(builder.Configuration).ValidateDataAnnotations().ValidateOnStart();
+builder.Configuration.AddYamlFile("manifest.yaml", true);
+builder.Services.AddOptions<ApplicationOptions>()
+    .Bind(builder.Configuration)
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
 builder.Services.AddRouting(options =>
 {
     options.LowercaseUrls = true;
     options.LowercaseQueryStrings = true;
 });
-builder.Services.AddControllers(options =>
+builder.Services
+    .AddControllers(options =>
 {
     options.Filters.Add<ProblemDetailsExceptionFilter>();
-}).AddJsonOptions(options =>
+})
+    .AddJsonOptions(options =>
 {
     JsonSerializer.DefaultOptionsConfiguration(options.JsonSerializerOptions);
 });
@@ -36,13 +39,13 @@ builder.Services.AddMediator(options =>
 });
 builder.Services.AddHttpClient();
 builder.Services.AddA2AAgents(builder.Configuration);
-builder.Services.AddDistributedMemoryCache(); //todo: replace
+builder.Services.AddCache(builder.Configuration);
 builder.Services.AddSingleton<IOAuth2TokenManager, OAuth2TokenManager>();
 builder.Services.AddSingleton<IChatHistoryManager, ChatHistoryManager>();
 builder.Services.AddSingleton<IKernelPluginManager, KernelPluginManager>();
 builder.Services.AddTransient<IKernelFactory, KernelFactory>();
 builder.Services.AddTransient<IAgentFactory, AgentFactory>();
-builder.Services.AddTransient<IAgenticProcessFactory, AgenticProcessFactory>();
+builder.Services.AddTransient<IProcessFactory, ProcessFactory>();
 builder.Services.AddTransient<IKernelFunctionStrategyFactory, KernelFunctionStrategyFactory>();
 
 var app = builder.Build();

--- a/src/DClare.Runtime.Api/Usings.cs
+++ b/src/DClare.Runtime.Api/Usings.cs
@@ -13,6 +13,7 @@
 
 global using A2A.Server.AspNetCore;
 global using DClare.Runtime.Api.Services;
+global using DClare.Runtime.Application;
 global using DClare.Runtime.Application.Configuration;
 global using DClare.Runtime.Application.Services;
 global using DClare.Runtime.Integration.Models;

--- a/src/DClare.Runtime.Api/appsettings.json
+++ b/src/DClare.Runtime.Api/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Cache": {
+    "Provider": "redis",
+    "Configuration": {
+      "ConnectionString": "localhost:6379",
+      "InstanceName": "GenAI"
+    }
+  }
 }

--- a/src/DClare.Runtime.Api/manifest.yaml
+++ b/src/DClare.Runtime.Api/manifest.yaml
@@ -1,28 +1,12 @@
+metadata:
+  name: GenAI
+  version: '1.0.0'
 components:
   kernels:
     bridgeit:
       reasoning:
         provider: azure-openai
         model: gpt-4o
-  agents:
-    bridgeit:
-      hosted:
-        description: A general-purpose assistant capable of performing a wide range of reasoning, generation, and analysis tasks
-        instructions: >
-          You are an advanced AI assistant.
-
-          Your purpose is to provide high-quality, context-aware responses to a wide variety of prompts. You may be asked to:
-          - Answer questions accurately and clearly
-          - Generate or edit structured and unstructured text
-          - Analyze input for correctness, clarity, or quality
-          - Help decompose or synthesize information
-          - Assist with reasoning, summarization, or evaluation
-          
-          Always respond with clarity, precision, and relevance. If the prompt is ambiguous or lacks sufficient context, respond by asking for clarification.
-          
-          You are expected to behave in a neutral, helpful, and objective manner at all times.
-        kernel:
-          use: bridgeit
   processes:
     reviewQuestion:
       convergence:
@@ -126,3 +110,25 @@ components:
                 Your task is to design and refine educational assessments that align with learning objectives, cognitive levels, and fair evaluation principles. Ensure that each question effectively measures knowledge, maintains validity, and avoids bias while promoting clear and meaningful assessment.
               kernel:
                 use: bridgeit
+interfaces:
+  agents:
+    bridgeit:
+      endpoints:
+        a2a: true
+      hosted:
+        description: A general-purpose assistant capable of performing a wide range of reasoning, generation, and analysis tasks
+        instructions: >
+          You are an advanced AI assistant.
+
+          Your purpose is to provide high-quality, context-aware responses to a wide variety of prompts. You may be asked to:
+          - Answer questions accurately and clearly
+          - Generate or edit structured and unstructured text
+          - Analyze input for correctness, clarity, or quality
+          - Help decompose or synthesize information
+          - Assist with reasoning, summarization, or evaluation
+          
+          Always respond with clarity, precision, and relevance. If the prompt is ambiguous or lacks sufficient context, respond by asking for clarification.
+          
+          You are expected to behave in a neutral, helpful, and objective manner at all times.
+        kernel:
+          use: bridgeit

--- a/src/DClare.Runtime.Application/CacheProvider.cs
+++ b/src/DClare.Runtime.Application/CacheProvider.cs
@@ -11,18 +11,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace DClare.Runtime.Application.Configuration;
+namespace DClare.Runtime.Application;
 
 /// <summary>
-/// Represents the options used to configure the DClare runtime
+/// Enumerates all supported cache providers
 /// </summary>
-public record ApplicationOptions
-    : Manifest
+public static class CacheProvider
 {
 
     /// <summary>
-    /// Gets/sets options used to configure the application's cache
+    /// Indicates a memory cache
     /// </summary>
-    public virtual CacheOptions Cache { get; set; } = new();
+    public const string Memory = "memory";
+    /// <summary>
+    /// Indicates a Redis cache
+    /// </summary>
+    public const string Redis = "redis";
+
+    /// <summary>
+    /// Gets a new <see cref="IEnumerable{T}"/> containing all supported values
+    /// </summary>
+    /// <returns>A <see cref="IEnumerable{T}"/> containing all supported values</returns>
+    public static IEnumerable<string> AsEnumerable()
+    {
+        yield return Memory;
+        yield return Redis;
+    }
 
 }

--- a/src/DClare.Runtime.Application/Commands/Agents/InvokeAgentCommandHandler.cs
+++ b/src/DClare.Runtime.Application/Commands/Agents/InvokeAgentCommandHandler.cs
@@ -27,7 +27,7 @@ public class InvokeAgentCommandHandler(IOptions<ApplicationOptions> options, IAg
     /// <inheritdoc/>
     public async Task<IOperationResult<ChatResponseStream>> HandleAsync(InvokeAgentCommand command, CancellationToken cancellationToken = default)
     {
-        if (options.Value.Components == null || options.Value.Components.Agents == null || !options.Value.Components.Agents.TryGetValue(command.Agent, out var agentDefinition) || agentDefinition == null) throw new ProblemDetailsException(Problems.AgentNotFound(command.Agent));
+        if (options.Value.Interfaces == null || options.Value.Interfaces.Agents == null || !options.Value.Interfaces.Agents!.TryGetValue(command.Agent, out var agentDefinition) || agentDefinition == null) throw new ProblemDetailsException(Problems.AgentNotFound(command.Agent));
         var agent = await agentFactory.CreateAsync(command.Agent, agentDefinition, options.Value.Components, cancellationToken).ConfigureAwait(false);
         var response = await agent.InvokeStreamingAsync(command.Message, command.SessionId, cancellationToken).ConfigureAwait(false);
         return this.Ok(response);

--- a/src/DClare.Runtime.Application/Commands/Processes/InvokeProcessCommandHandler.cs
+++ b/src/DClare.Runtime.Application/Commands/Processes/InvokeProcessCommandHandler.cs
@@ -18,14 +18,14 @@ namespace DClare.Runtime.Application.Commands.Processes;
 /// <summary>
 /// Represents the service used to process <see cref="InvokeProcessCommand"/>s
 /// </summary>
-public class InvokeProcessCommandHandler(IOptions<ApplicationOptions> options, IAgenticProcessFactory processFactory)
+public class InvokeProcessCommandHandler(IOptions<ApplicationOptions> options, IProcessFactory processFactory)
     : ICommandHandler<InvokeProcessCommand, ChatResponseStream>
 {
 
     /// <inheritdoc/>
     public async Task<IOperationResult<ChatResponseStream>> HandleAsync(InvokeProcessCommand command, CancellationToken cancellationToken = default)
     {
-        if (options.Value.Components == null || options.Value.Components.Processes == null || !options.Value.Components.Processes.TryGetValue(command.Process, out var processDefinition) || processDefinition == null) throw new ProblemDetailsException(Problems.AgenticProcessNotFound(command.Process));
+        if (options.Value.Interfaces == null || options.Value.Interfaces.Processes == null || !options.Value.Interfaces.Processes!.TryGetValue(command.Process, out var processDefinition) || processDefinition == null) throw new ProblemDetailsException(Problems.AgenticProcessNotFound(command.Process));
         var process = await processFactory.CreateAsync(processDefinition, options.Value.Components, cancellationToken).ConfigureAwait(false);
         var response = await process.InvokeStreamingAsync(command.Message, command.SessionId, cancellationToken).ConfigureAwait(false);
         return this.Ok(response);

--- a/src/DClare.Runtime.Application/Configuration/CacheOptions.cs
+++ b/src/DClare.Runtime.Application/Configuration/CacheOptions.cs
@@ -14,15 +14,19 @@
 namespace DClare.Runtime.Application.Configuration;
 
 /// <summary>
-/// Represents the options used to configure the DClare runtime
+/// Represents the options used to configure the application's cache
 /// </summary>
-public record ApplicationOptions
-    : Manifest
+public record CacheOptions
 {
 
     /// <summary>
-    /// Gets/sets options used to configure the application's cache
+    /// Gets/sets the name of the cache provider to use
     /// </summary>
-    public virtual CacheOptions Cache { get; set; } = new();
+    public virtual string Provider { get; set; } = CacheProvider.Memory;
+
+    /// <summary>
+    /// gets/sets a key/value mapping, if any, containing provider-specific configuration
+    /// </summary>
+    public virtual IDictionary<string, object>? Configuration { get; set; }
 
 }

--- a/src/DClare.Runtime.Application/DClare.Runtime.Application.csproj
+++ b/src/DClare.Runtime.Application/DClare.Runtime.Application.csproj
@@ -23,13 +23,15 @@
 	<PackageReference Include="a2a-net.Client.Http" Version="0.4.1" />
 	<PackageReference Include="a2a-net.Server" Version="0.4.1" />
 	<PackageReference Include="a2a-net.Server.Infrastructure.DistributedCache" Version="0.4.1" />
-	<PackageReference Include="DClare.Sdk" Version="0.1.1" />
+	<PackageReference Include="DClare.Sdk" Version="0.2.0" />
 	<PackageReference Include="Duende.IdentityModel" Version="7.0.0" />
 	<PackageReference Include="mcpdotnet" Version="1.2.0.1" />
-	<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.8.0" />
-	<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.8.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.46.0" />
-	<PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.46.0" />
+	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
+	<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.2" />
+	<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.9.0" />
+	<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.9.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.47.0" />
+	<PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.47.0" />
 	<PackageReference Include="Microsoft.SemanticKernel.Connectors.Google" Version="1.46.0-alpha" />
 	<PackageReference Include="Microsoft.SemanticKernel.Connectors.HuggingFace" Version="1.46.0-preview" />
 	<PackageReference Include="Microsoft.SemanticKernel.Connectors.MistralAI" Version="1.46.0-alpha" />

--- a/src/DClare.Runtime.Application/Services/A2AAgentRuntime.cs
+++ b/src/DClare.Runtime.Application/Services/A2AAgentRuntime.cs
@@ -22,7 +22,7 @@ namespace DClare.Runtime.Application.Services;
 /// </summary>
 /// <param name="name">The name of the <see cref="IAgent"/> to invoke</param>
 /// <param name="definition">The definition of the <see cref="IAgent"/> to invoke</param>
-/// <param name="components">A collection, if any, containing the reusable components available to the <see cref="IAgenticProcess"/></param>
+/// <param name="components">A collection, if any, containing the reusable components available to the <see cref="IProcess"/></param>
 /// <param name="agentFactory">The service used to create <see cref="IAgent"/>s</param>
 public class A2AAgentRuntime(string name, AgentDefinition definition, ComponentCollectionDefinition? components, IAgentFactory agentFactory)
     : IAgentRuntime
@@ -39,7 +39,7 @@ public class A2AAgentRuntime(string name, AgentDefinition definition, ComponentC
     protected AgentDefinition Definition { get; } = definition;
 
     /// <summary>
-    /// Gets a collection, if any, containing the reusable components available to the <see cref="IAgenticProcess"/>
+    /// Gets a collection, if any, containing the reusable components available to the <see cref="IProcess"/>
     /// </summary>
     protected ComponentCollectionDefinition? Components { get; } = components;
 

--- a/src/DClare.Runtime.Application/Services/CollaborationProcess.cs
+++ b/src/DClare.Runtime.Application/Services/CollaborationProcess.cs
@@ -16,22 +16,22 @@ using DClare.Sdk.Models.Processes;
 namespace DClare.Runtime.Application.Services;
 
 /// <summary>
-/// Represents a collaboration implementation of the <see cref="IAgenticProcess"/> interface
+/// Represents a collaboration implementation of the <see cref="IProcess"/> interface
 /// </summary>
-/// <param name="definition">The <see cref="IAgenticProcess"/>'s definition</param>
-/// <param name="components">A a collection, if any, containing the reusable components available to the <see cref="IAgenticProcess"/></param>
+/// <param name="definition">The <see cref="IProcess"/>'s definition</param>
+/// <param name="components">A a collection, if any, containing the reusable components available to the <see cref="IProcess"/></param>
 /// <param name="logger">The service used to perform logging</param>
-public class CollaborationAgenticProcess(CollaborationAgenticProcessDefinition definition, ComponentCollectionDefinition? components, ILogger<CollaborationAgenticProcess> logger)
-    : IAgenticProcess
+public class CollaborationProcess(CollaborationAgenticProcessDefinition definition, ComponentCollectionDefinition? components, ILogger<CollaborationProcess> logger)
+    : IProcess
 {
 
     /// <summary>
-    /// Gets the <see cref="IAgenticProcess"/>'s definition
+    /// Gets the <see cref="IProcess"/>'s definition
     /// </summary>
     protected CollaborationAgenticProcessDefinition Definition { get; } = definition;
 
     /// <summary>
-    /// Gets a collection, if any, containing the reusable components available to the <see cref="IAgenticProcess"/>
+    /// Gets a collection, if any, containing the reusable components available to the <see cref="IProcess"/>
     /// </summary>
     protected ComponentCollectionDefinition? Components { get; } = components;
 

--- a/src/DClare.Runtime.Application/Services/Interfaces/IProcess.cs
+++ b/src/DClare.Runtime.Application/Services/Interfaces/IProcess.cs
@@ -16,7 +16,7 @@ namespace DClare.Runtime.Application.Services;
 /// <summary>
 /// Defines the fundamentals of a high-level orchestration process involving one or more agents
 /// </summary>
-public interface IAgenticProcess
+public interface IProcess
 {
 
     /// <summary>

--- a/src/DClare.Runtime.Application/Services/Interfaces/IProcessFactory.cs
+++ b/src/DClare.Runtime.Application/Services/Interfaces/IProcessFactory.cs
@@ -14,18 +14,18 @@
 namespace DClare.Runtime.Application.Services;
 
 /// <summary>
-/// Defines the fundamentals of a service used to create <see cref="IAgenticProcess"/>es
+/// Defines the fundamentals of a service used to create <see cref="IProcess"/>es
 /// </summary>
-public interface IAgenticProcessFactory
+public interface IProcessFactory
 {
 
     /// <summary>
-    /// Creates a new <see cref="IAgenticProcess"/>
+    /// Creates a new <see cref="IProcess"/>
     /// </summary>
-    /// <param name="definition">The definition of the <see cref="IAgenticProcess"/> to create</param>
-    /// <param name="components">A collection, if any, containing the reusable components potentially referenced by the <see cref="IAgenticProcess"/> to create</param>
+    /// <param name="definition">The definition of the <see cref="IProcess"/> to create</param>
+    /// <param name="components">A collection, if any, containing the reusable components potentially referenced by the <see cref="IProcess"/> to create</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
-    /// <returns>A new <see cref="IAgenticProcess"/></returns>
-    Task<IAgenticProcess> CreateAsync(AgenticProcessDefinition definition, ComponentCollectionDefinition? components = null, CancellationToken cancellationToken = default);
+    /// <returns>A new <see cref="IProcess"/></returns>
+    Task<IProcess> CreateAsync(ProcessDefinition definition, ComponentCollectionDefinition? components = null, CancellationToken cancellationToken = default);
 
 }

--- a/src/DClare.Runtime.Application/Services/KernelFactory.cs
+++ b/src/DClare.Runtime.Application/Services/KernelFactory.cs
@@ -86,7 +86,7 @@ public class KernelFactory(ILoggerFactory loggerFactory, IOAuth2TokenManager oau
     {
         ArgumentNullException.ThrowIfNull(kernelBuilder);
         ArgumentNullException.ThrowIfNull(reasoningCapability);
-        var apiKey = reasoningCapability.Api.Endpoint.Authentication?.Scheme switch
+        var apiKey = reasoningCapability.Api.Endpoint?.Authentication?.Scheme switch
         {
             AuthenticationScheme.ApiKey => reasoningCapability.Api.Endpoint.Authentication.ApiKey!.Key,
             AuthenticationScheme.Bearer => reasoningCapability.Api.Endpoint.Authentication.Bearer!.Token,
@@ -97,7 +97,7 @@ public class KernelFactory(ILoggerFactory loggerFactory, IOAuth2TokenManager oau
         {
             case ReasoningModelProvider.AzureOpenAI:
                 if (reasoningCapability.Api.Properties == null || !reasoningCapability.Api.Properties.TryGetValue("deployment", out var value) || value is not string deployment || string.IsNullOrWhiteSpace(deployment)) throw new NullReferenceException($"The 'deployment' API property must be set when using the '{ReasoningModelProvider.AzureOpenAI}' reasoning model provider");
-                if (reasoningCapability.Api.Endpoint == null) throw new NullReferenceException($"'{nameof(reasoningCapability)}.{nameof(reasoningCapability.Api)}.{nameof(reasoningCapability.Api.Endpoint)}' must be set when using the '{ReasoningModelProvider.AzureOpenAI}' reasoning model provider");
+                if (reasoningCapability.Api.Endpoint?.Uri == null) throw new NullReferenceException($"'{nameof(reasoningCapability)}.{nameof(reasoningCapability.Api)}.{nameof(reasoningCapability.Api.Endpoint)}' must be set when using the '{ReasoningModelProvider.AzureOpenAI}' reasoning model provider");
                 if (string.IsNullOrWhiteSpace(apiKey)) throw new NullReferenceException("Failed to resolve the API Key to use");
                 kernelBuilder.AddAzureOpenAIChatCompletion(deployment, reasoningCapability.Api.Endpoint.Uri.OriginalString, apiKey, reasoningCapability.Provider, reasoningCapability.Model);
                 break;
@@ -106,15 +106,15 @@ public class KernelFactory(ILoggerFactory loggerFactory, IOAuth2TokenManager oau
                 kernelBuilder.AddGoogleAIGeminiChatCompletion(reasoningCapability.Model, apiKey, serviceId: reasoningCapability.Provider);
                 break;
             case ReasoningModelProvider.HuggingFace:
-                if (reasoningCapability.Api.Endpoint == null) throw new NullReferenceException($"'{nameof(reasoningCapability)}.{nameof(reasoningCapability.Api)}.{nameof(reasoningCapability.Api.Endpoint)}' must be set when using the '{ReasoningModelProvider.HuggingFace}' reasoning model provider");
+                if (reasoningCapability.Api.Endpoint?.Uri == null) throw new NullReferenceException($"'{nameof(reasoningCapability)}.{nameof(reasoningCapability.Api)}.{nameof(reasoningCapability.Api.Endpoint)}' must be set when using the '{ReasoningModelProvider.HuggingFace}' reasoning model provider");
                 kernelBuilder.AddHuggingFaceChatCompletion(reasoningCapability.Api.Endpoint.Uri, apiKey, reasoningCapability.Provider);
                 break;
             case ReasoningModelProvider.MistralAI:
                 if (string.IsNullOrWhiteSpace(apiKey)) throw new NullReferenceException("Failed to resolve the API Key to use");
-                kernelBuilder.AddMistralChatCompletion(reasoningCapability.Model, apiKey, reasoningCapability.Api.Endpoint.Uri, reasoningCapability.Provider);
+                kernelBuilder.AddMistralChatCompletion(reasoningCapability.Model, apiKey, reasoningCapability.Api.Endpoint?.Uri, reasoningCapability.Provider);
                 break;
             case ReasoningModelProvider.Ollama:
-                if (reasoningCapability.Api.Endpoint == null) throw new NullReferenceException($"'{nameof(reasoningCapability)}.{nameof(reasoningCapability.Api)}.{nameof(reasoningCapability.Api.Endpoint)}' must be set when using the '{ReasoningModelProvider.Ollama}' reasoning model provider");
+                if (reasoningCapability.Api.Endpoint?.Uri == null) throw new NullReferenceException($"'{nameof(reasoningCapability)}.{nameof(reasoningCapability.Api)}.{nameof(reasoningCapability.Api.Endpoint)}' must be set when using the '{ReasoningModelProvider.Ollama}' reasoning model provider");
                 kernelBuilder.AddOllamaChatCompletion(reasoningCapability.Model, reasoningCapability.Api.Endpoint.Uri, reasoningCapability.Provider);
                 break;
             case ReasoningModelProvider.Onnx:
@@ -124,7 +124,7 @@ public class KernelFactory(ILoggerFactory loggerFactory, IOAuth2TokenManager oau
             case ReasoningModelProvider.OpenAI:
                 var organization = reasoningCapability.Api.Properties == null || !reasoningCapability.Api.Properties.TryGetValue("organization", out value) ? null : value as string;
                 if (string.IsNullOrWhiteSpace(apiKey)) throw new NullReferenceException("Failed to resolve the API Key to use");
-                if (reasoningCapability.Api.Endpoint.Uri == null) kernelBuilder.AddOpenAIChatCompletion(reasoningCapability.Model, apiKey, organization, reasoningCapability.Provider);
+                if (reasoningCapability.Api.Endpoint?.Uri == null) kernelBuilder.AddOpenAIChatCompletion(reasoningCapability.Model, apiKey, organization, reasoningCapability.Provider);
                 else kernelBuilder.AddOpenAIChatCompletion(reasoningCapability.Model, reasoningCapability.Api.Endpoint.Uri, apiKey, organization, reasoningCapability.Provider);
                 break;
             default:

--- a/src/DClare.Runtime.Application/Services/ProcessFactory.cs
+++ b/src/DClare.Runtime.Application/Services/ProcessFactory.cs
@@ -14,11 +14,11 @@
 namespace DClare.Runtime.Application.Services;
 
 /// <summary>
-/// Represents the default implementation of the <see cref="IAgenticProcessFactory"/> interface
+/// Represents the default implementation of the <see cref="IProcessFactory"/> interface
 /// </summary>
 /// <param name="serviceProvider">The current <see cref="IServiceProvider"/></param>
-public class AgenticProcessFactory(IServiceProvider serviceProvider)
-    : IAgenticProcessFactory
+public class ProcessFactory(IServiceProvider serviceProvider)
+    : IProcessFactory
 {
 
     /// <summary>
@@ -27,13 +27,13 @@ public class AgenticProcessFactory(IServiceProvider serviceProvider)
     protected IServiceProvider ServiceProvider { get; } = serviceProvider;
 
     /// <inheritdoc/>
-    public virtual Task<IAgenticProcess> CreateAsync(AgenticProcessDefinition definition, ComponentCollectionDefinition? components = null, CancellationToken cancellationToken = default)
+    public virtual Task<IProcess> CreateAsync(ProcessDefinition definition, ComponentCollectionDefinition? components = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(definition);
-        return Task.FromResult<IAgenticProcess>(definition.Type switch
+        return Task.FromResult<IProcess>(definition.Type switch
         {
-            AgenticProcessType.Collaboration => ActivatorUtilities.CreateInstance<CollaborationAgenticProcess>(ServiceProvider, definition.Collaboration!, components!),
-            AgenticProcessType.Convergence => ActivatorUtilities.CreateInstance<ConvergenceAgenticProcess>(ServiceProvider, definition.Convergence!, components!),
+            ProcessType.Collaboration => ActivatorUtilities.CreateInstance<CollaborationProcess>(ServiceProvider, definition.Collaboration!, components!),
+            ProcessType.Convergence => ActivatorUtilities.CreateInstance<ConvergenceProcess>(ServiceProvider, definition.Convergence!, components!),
             _ => throw new NotSupportedException($"The specified agentic process type '{definition.Type}' is not supported")
         });
     }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

- Make `ApplicationOptions` inherit from `Manifest` and support cache configuration
- Change `ApplicationOptions` to inherit from the D-Clare `Manifest` structure
- Add means to configure the application's caching behavior
- Fix `HostedAgent` to persist `ChatHistory`, enabling session continuity